### PR TITLE
removed c4,m4,r4 types from on demand because they're more expensive …

### DIFF
--- a/src/templates/gwfcore/gwfcore-batch.template.yaml
+++ b/src/templates/gwfcore/gwfcore-batch.template.yaml
@@ -194,23 +194,12 @@ Resources:
       Type: MANAGED
       State: ENABLED
       ComputeResources:
+        AllocationStrategy: BEST_FIT_PROGRESSIVE
         LaunchTemplate:
           LaunchTemplateId: !Ref LaunchTemplateId
           Version: $Latest
         InstanceRole:  !Ref Ec2InstanceProfileArn
         InstanceTypes:
-          - c4.large
-          - m4.large
-          - r4.large
-          - c4.xlarge
-          - m4.xlarge
-          - r4.xlarge
-          - c4.2xlarge
-          - m4.2xlarge
-          - r4.2xlarge
-          - c4.4xlarge
-          - m4.4xlarge
-          - r4.4xlarge
           - c5.large
           - m5.large
           - r5.large

--- a/src/templates/gwfcore/gwfcore-batch.template.yaml
+++ b/src/templates/gwfcore/gwfcore-batch.template.yaml
@@ -194,7 +194,7 @@ Resources:
       Type: MANAGED
       State: ENABLED
       ComputeResources:
-        AllocationStrategy: BEST_FIT_PROGRESSIVE
+        AllocationStrategy: BEST_FIT
         LaunchTemplate:
           LaunchTemplateId: !Ref LaunchTemplateId
           Version: $Latest


### PR DESCRIPTION
*Description of changes:*
Removed 4th gen EC2 types from on demand compute env

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
